### PR TITLE
Fix compatibility with tizk 3.1.10

### DIFF
--- a/spectralsequences/src/sseqcheckdefinitions.code.tex
+++ b/spectralsequences/src/sseqcheckdefinitions.code.tex
@@ -20,6 +20,7 @@
 \def\sseq@checkdef@#1{
     \@xp\ifx\csname sseq@check@\sseq@macroname#1\endcsname#1\else
         \sseq@tempiffalse
+        % \@xp\typeout\@xp{\sseq@macroname#1}
     \fi
 }
 
@@ -80,6 +81,20 @@
    \expandafter\pgfkeys@code\pgfkeyscurrentvalue\pgfeov}
   {\pgfkeys@case@two}%
 }
+
+\ifsseq@tempif\else
+  % Try again with new v3.1.10 definition
+  \sseq@tempiftrue
+  \sseq@checkdef\pgfkeys@case@one{%
+    \pgfkeysifdefined{\pgfkeyscurrentkey/.@cmd}%
+    {\pgfkeysgetvalue{\pgfkeyscurrentkey/.@cmd}{\pgfkeys@code}%
+      \ifx\pgfkeys@code\relax\expandafter\pgfkeys@firstoftwo\else\expandafter\pgfkeys@secondoftwo\fi
+      {\pgfkeys@unknown}%
+      {\expandafter\pgfkeys@code\pgfkeyscurrentvalue\pgfeov}}
+    {\pgfkeys@case@two}%
+  }
+\fi
+
 
 \sseq@checkdef\pgfkeys@case@two@extern{%
   \ifx\pgfkeyscurrentvalue\pgfkeysnovalue@text%

--- a/spectralsequences/src/sseqkeys.code.tex
+++ b/spectralsequences/src/sseqkeys.code.tex
@@ -316,8 +316,12 @@
 \def\sseq@pgfkeys@case@one@store{%
     \pgfkeysifdefined{\pgfkeyscurrentkey/.@cmd}%
     {\pgfkeysgetvalue{\pgfkeyscurrentkey/.@cmd}{\pgfkeys@code}%
-      \ifx\pgfkeys@code\relax\expandafter\pgfkeys@firstoftwo\else\expandafter\pgfkeys@secondoftwo\fi
+      \ifx\pgfkeys@code\relax\expandafter\@firstoftwo\else\expandafter\@secondoftwo\fi
       {\pgfkeys@unknown}%
+      % The following line is the only change, it used to be
+      % \@xp\pgfkeys@code\pgfkeyscurrentvalue\pgfeov which would just run the
+      % code. Instead we recursively expand the \pgfkeysalso's and then store in
+      % it in \sseq@savedoptioncode
       {\sseq@eval{\@nx\sseq@keys@addtooptions@checkalso{\unexpanded\@xptwo{\@xp\pgfkeys@code\pgfkeyscurrentvalue\pgfeov}}}}}%
     {\pgfkeys@case@two}%
 }

--- a/spectralsequences/src/sseqkeys.code.tex
+++ b/spectralsequences/src/sseqkeys.code.tex
@@ -314,12 +314,12 @@
 \let\sseq@pgfkeys@case@one@save\pgfkeys@case@one
 \let\sseq@pgfkeys@case@two@extern@save\pgfkeys@case@two@extern
 \def\sseq@pgfkeys@case@one@store{%
-    \pgfkeysifdefined{\pgfkeyscurrentkey/.@cmd}{%
-        \pgfkeysgetvalue{\pgfkeyscurrentkey/.@cmd}{\pgfkeys@code}%
-        % The following line is the only change, it used to be \@xp\pgfkeys@code\pgfkeyscurrentvalue\pgfeov which would just run the code.
-        % Instead we recursively expand the \pgfkeysalso's and then store in it \sseq@savedoptioncode
-        \sseq@eval{\@nx\sseq@keys@addtooptions@checkalso{\unexpanded\@xptwo{\@xp\pgfkeys@code\pgfkeyscurrentvalue\pgfeov}}}%
-    }{\pgfkeys@case@two}%
+    \pgfkeysifdefined{\pgfkeyscurrentkey/.@cmd}%
+    {\pgfkeysgetvalue{\pgfkeyscurrentkey/.@cmd}{\pgfkeys@code}%
+      \ifx\pgfkeys@code\relax\expandafter\pgfkeys@firstoftwo\else\expandafter\pgfkeys@secondoftwo\fi
+      {\pgfkeys@unknown}%
+      {\sseq@eval{\@nx\sseq@keys@addtooptions@checkalso{\unexpanded\@xptwo{\@xp\pgfkeys@code\pgfkeyscurrentvalue\pgfeov}}}}}%
+    {\pgfkeys@case@two}%
 }
 \def\sseq@pgfkeys@case@two@extern@store{%
   \ifx\pgfkeyscurrentvalue\pgfkeysnovalue@text%


### PR DESCRIPTION
The definition of `\pgfkeys@case@one` has changed. Update the patches to reflect this.